### PR TITLE
Fix constraint definition for state-bounds constraints in the MPCReferenceTrajectory class

### DIFF
--- a/backend/ref_traj_generation.py
+++ b/backend/ref_traj_generation.py
@@ -63,7 +63,8 @@ class MPCReferenceTrajectory:
 
             # state bounds
             if self.state_Ax_leq_b is not None:
-                self.constraints += [np.array(self.state_Ax_leq_b['A']) @ self.x[:, t + 1]]
+                self.constraints += [np.array(self.state_Ax_leq_b['A']) @ self.x[:, t + 1]
+                                     <= np.array(self.state_Ax_leq_b['b'])]
 
             # input bounds
             if self.control_Ax_leq_b is not None:


### PR DESCRIPTION
Typo in the constraint definition for state bounds in the MPCReferenceTrajectory class. 

Note that the MPCFilter and MPCFilterWithSlack classes in backend/safety_filters.py have the appropriate definitions. Similar syntax and styling were followed.